### PR TITLE
추가: 아이디, 비밀번호 찾기 틀 제작 및 페이지 이동 연동[FIPP]

### DIFF
--- a/askFront/src/App.js
+++ b/askFront/src/App.js
@@ -7,6 +7,9 @@ import StudyImg from "./component/studycp/StudyImg";
 import Login from "./layout/login/Login";
 import Write from "./layout/write/Write";
 import SignUp from "./layout/sign up/SignUp";
+import Email from "./layout/forgot/Email";
+import Password from "./layout/forgot/Password";
+import PasswordSet from "./layout/forgot/PasswordSet";
 
 function App() {
 
@@ -27,7 +30,10 @@ function App() {
         <Route path="/studyImg" element={<StudyImg />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<SignUp />} />
-        <Route path="/write" element={<Write />}/>
+        <Route path="/write" element={<Write />} />
+        <Route path="/forgotE" element={<Email />} />
+        <Route path="/forgotP" element={<Password />} />
+        <Route path="/forgotPS" element={<PasswordSet />} />
       </Routes>
     </>
   );

--- a/askFront/src/layout/forgot/Email.jsx
+++ b/askFront/src/layout/forgot/Email.jsx
@@ -1,0 +1,16 @@
+function Email () {
+
+    // 알림창으로 닉네임이 있을경우 이메일을 알려줌
+
+    return(
+        <div>
+            <h1>아이디 찾기</h1>
+            <div>
+                <input type="text" placeholder="닉네임을 입력해주세요."/>
+                <button>조회하기</button>
+            </div>
+        </div>
+    );
+}
+
+export default Email;

--- a/askFront/src/layout/forgot/Password.jsx
+++ b/askFront/src/layout/forgot/Password.jsx
@@ -1,0 +1,21 @@
+import { useNavigate } from "react-router-dom";
+
+function Password () {
+
+    // 조회를 해서 이메일과 닉네임이 일치한다면 비밀번호 재설정을 할 수 있게 이동 시켜 줌.
+    
+    const navigate = useNavigate();
+
+    return(
+        <div>
+            <h1>비밀번호 찾기</h1>
+            <div>
+                <input type="email" placeholder="이메일을 입력해주세요."/>
+                <input type="text" placeholder="닉네임을 입력해주세요."/>
+                <button>조회하기</button>
+            </div>
+        </div>
+    );
+}
+
+export default Password;

--- a/askFront/src/layout/forgot/PasswordSet.jsx
+++ b/askFront/src/layout/forgot/PasswordSet.jsx
@@ -1,0 +1,17 @@
+function PasswordSet () {
+
+    // 비밀번호를 재설정 후 로그인 페이지로 이동하게 함.
+    
+    return(
+        <div>
+            <h1>비밀번호 재설정</h1>
+            <div>
+                <input type="password" placeholder="비밀번호를 입력해주세요."/>
+                <input type="password" placeholder="비밀번호를 다시 한 번 입력해주세요."/>
+                <button>조회하기</button>
+            </div>
+        </div>
+    );
+}
+
+export default PasswordSet;

--- a/askFront/src/layout/login/Login.jsx
+++ b/askFront/src/layout/login/Login.jsx
@@ -43,7 +43,8 @@ function Login() {
                                     <label for="remember" class="text-gray-500 dark:text-gray-300">아이디 저장</label>
                                 </div>
                             </div>
-                            <button href="#" class="text-sm font-medium text-primary-600 hover:underline">비밀번호 찾기</button>
+                            <button class="text-sm font-medium text-primary-600 hover:underline" onClick={()=> navigate('/forgotE')}>아이디 찾기</button>
+                            <button class="text-sm font-medium text-primary-600 hover:underline" onClick={()=> navigate('/forgotP')}>비밀번호 찾기</button>
                         </div>
                         <button type="submit" class="w-full bg-blue-600 text-white focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center hover:bg-blue-500">로그인</button>
                         <p class="text-sm font-light text-gray-500 "> 회원이 아니시라고요? 


### PR DESCRIPTION
## 7,8일차 성원 Today (12월 18,9일)
- 아이디 찾기 비밀번호 찾기 틀 제작 및 페이지 이동 연동을 작업했습니다.
- 7일차 부분에 커밋 오류로 인하여 작성한 코드 유실 8일차에 재작업을 진행했습니다.

## 체크리스트
- [x] 아이디 찾기 컴포넌트 생성
- [x] 아이디 찾기 틀 작업
- [x] 아이디 찾기 페이지 이동 작업
- [x] 비밀번호 찾기 컴포넌트 생성
- [x] 비밀번호 재설정 컴포넌트 생성
- [x] 비밀번호 찾기 틀 작업
- [x] 비밀번호 재설정 틀 작업
- [x] 비밀번호 찾기 페이지 이동 작업
- [x] 비밀번호 재설정 페이지 이동 작업
